### PR TITLE
Set the sort for Query

### DIFF
--- a/src/Model/Index/SearchIndex.php
+++ b/src/Model/Index/SearchIndex.php
@@ -49,7 +49,8 @@ class SearchIndex extends Index
                     ->setFields(['contents', 'title^3'])
                     ->setDefaultOperator('AND');
                 return $q;
-            });
+            })
+            ->order($options['sort']);
 
         /** @var \Cake\ElasticSearch\ResultSet $results  */
         $results = $query->all();


### PR DESCRIPTION
I don't see anything applying the options. Shouldn't we set the sort for the results?