### PR TITLE
Drop transforming the search version

### DIFF
--- a/src/Controller/SearchController.php
+++ b/src/Controller/SearchController.php
@@ -47,7 +47,7 @@ class SearchController extends AppController
 
             throw $e;
         }
-        $version = $this->getSearchVersion($version);
+        $version = trim($version);
         if (!$version) {
             $e = new BadRequestException();
             $e->setHeader('X-Reason', 'missing-version');
@@ -106,45 +106,5 @@ class SearchController extends AppController
             ->setOption('serialize', 'results');
 
         $this->set('results', $results);
-    }
-
-    /**
-     * Get the search version. Account for backwards compatible names
-     * as book rebuilds take some time.
-     *
-     * @param string$version The request version to transform into the search version.
-     * @return string
-     */
-    protected function getSearchVersion(string $version): string
-    {
-        switch ($version) {
-            case 'authorization-11':
-                return 'authorization-1';
-
-            case 'authentication-11':
-                return 'authentication-1';
-
-            case '1-1':
-                return '11';
-
-            case '1-2':
-                return '12';
-
-            case '1-3':
-                return '13';
-
-            case '3-0':
-                return '30';
-
-            case '4-0':
-                return '40';
-
-            case '2-10':
-            case '2-2':
-                return '20';
-
-            default:
-                return $version;
-        }
     }
 }

--- a/tests/TestCase/Controller/SearchControllerTest.php
+++ b/tests/TestCase/Controller/SearchControllerTest.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace App\Test\TestCase\Controller;
 
-use App\Model\Index\SearchIndex;
 use Cake\ElasticSearch\IndexRegistry;
 use Cake\TestSuite\IntegrationTestTrait;
 use Cake\TestSuite\TestCase;
@@ -367,48 +366,5 @@ class SearchControllerTest extends TestCase
                 'subsection',
             ],
         ]);
-    }
-
-    /**
-     * @return string[][]
-     */
-    public function searchVersionDataProvider(): array
-    {
-        return [
-            ['authorization-11', 'authorization-1'],
-            ['authentication-11', 'authentication-1'],
-            ['1-1', '11'],
-            ['1-2', '12'],
-            ['1-3', '13'],
-            ['3-0', '30'],
-            ['4-0', '40'],
-            ['2-10', '20'],
-            ['2-2', '20'],
-            ['other', 'other'],
-        ];
-    }
-
-    /**
-     * @dataProvider searchVersionDataProvider
-     * @param string $version The request version.
-     * @param string $expected The expected search version.
-     * @return void
-     */
-    public function testSearchVersionTranslation(string $version, string $expected): void
-    {
-        $index = $this
-            ->getMockBuilder(SearchIndex::class)
-            ->onlyMethods(['search'])
-            ->getMock();
-
-        $index
-            ->expects($this->once())
-            ->method('search')
-            ->with('en', $expected)
-            ->willReturn([]);
-
-        IndexRegistry::set('Search', $index);
-
-        $this->get("/search?lang=en&version={$version}&q=query");
     }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -11,3 +11,7 @@ require dirname(__DIR__) . '/config/bootstrap.php';
 
 // dummy default connection to make the fixture manager happy
 \Cake\Datasource\ConnectionManager::setConfig('default', []);
+
+// disable logging in tests to avoid polluting the CLI output
+\Cake\Log\Log::drop('debug');
+\Cake\Log\Log::drop('error');


### PR DESCRIPTION
Instead we rely on the individual docs configuration to match the
version of the alias 1:1.