### PR TITLE
Accept version strings in dot separated format.

### DIFF
--- a/src/Model/Index/SearchIndex.php
+++ b/src/Model/Index/SearchIndex.php
@@ -6,6 +6,7 @@ namespace App\Model\Index;
 use App\Datasource\Query as AppQuery;
 use App\QueryTranslation\QueryString;
 use Cake\ElasticSearch\Index;
+use Cake\Utility\Text;
 use Elastica\Aggregation\Cardinality;
 use Elastica\Query\BoolQuery;
 use Elastica\Query\FunctionScore;
@@ -51,7 +52,7 @@ class SearchIndex extends Index
             'encoder' => 'default',
         ];
 
-        $this->setName(implode('-', ['cake-docs', $version, $lang]));
+        $this->setName(implode('-', ['cake-docs', Text::slug($version), $lang]));
 
         $minLimit = 1;
         $maxLimit = 100;


### PR DESCRIPTION
This allows to use version strings like `4.next` instead of `4-next` for the `search_version` docs theme config option, unifying the format used in all the different places, so no special format has to be remembered.

This change is backwards compatible, the various docs config files can be updated once this change is live and there should be no downtime.